### PR TITLE
Allow .* in select statements

### DIFF
--- a/lib/anbt-sql-formatter/parser.rb
+++ b/lib/anbt-sql-formatter/parser.rb
@@ -134,7 +134,10 @@ class AnbtSql
       elsif letter?(@char)
         s = ""
         # 文字列中のドットについては、文字列と一体として考える。
-        while (letter?(@char) || digit?(@char) || @char == '.')
+        # Dots and dot-stars are treated as one unit in the string. This
+        # allows us to treat `my_table.*` in `select my_table.* from ...` as a
+        # single token.
+        while (letter?(@char) || digit?(@char) || @char == '.' || @char == '*')
           s += @char
           @pos += 1
           if (@pos >= @before.length())

--- a/test/test_formatter.rb
+++ b/test/test_formatter.rb
@@ -523,6 +523,21 @@ class TestAnbtSqlFormatter < Test::Unit::TestCase
     )
   end
 
+  def test_format_select_all
+    assert_equals(
+      "should allow .* in selections",
+      strip_indent(
+        <<-EOB
+        SELECT
+        <-indent-><-indent->my_table.*
+        <-indent->FROM
+        <-indent-><-indent->my_table
+        ;
+        EOB
+      ),
+      @fmt.format("SELECT my_table.* FROM my_table;")
+    )
+  end
 
   def test_split_to_statements
     msg = "split_to_statements - "


### PR DESCRIPTION
This allows the formatter to handle `select my_table.* from ...`. Before this commit, it would write `select my_table. * from ...` because the `*` was treated as a separate token.